### PR TITLE
ref: Apply colibri2 connects as id-keyed create/expire deltas

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/Conference.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/Conference.java
@@ -1295,9 +1295,9 @@ public class Conference
         }
     }
 
-    public void setConnects(List<Connect> exports)
+    public void applyConnects(List<Connect> connects)
     {
-        exporter.setConnects(exports);
+        exporter.applyConnects(connects);
     }
 
     public boolean hasRelays()

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/colibri2/Colibri2ConferenceHandler.kt
@@ -75,7 +75,7 @@ class Colibri2ConferenceHandler(
         for (e in conferenceModifyIQ.endpoints) {
             responseBuilder.addEndpoint(handleColibri2Endpoint(e, ignoreUnknownEndpoints))
         }
-        conferenceModifyIQ.connects?.let { conference.setConnects(it.getConnects()) }
+        conferenceModifyIQ.connects?.let { conference.applyConnects(it.getConnects()) }
         for (r in conferenceModifyIQ.relays) {
             if (!RelayConfig.config.enabled) {
                 throw IqProcessingException(Condition.feature_not_implemented, "Octo is disabled in configuration.")

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterWrapper.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/export/ExporterWrapper.kt
@@ -23,7 +23,9 @@ import org.jitsi.utils.logging2.Logger
 import org.jitsi.utils.logging2.createChildLogger
 import org.jitsi.videobridge.PotentialPacketHandler
 import org.jitsi.videobridge.colibri2.FeatureNotImplementedException
+import org.jitsi.videobridge.colibri2.IqProcessingException
 import org.jitsi.xmpp.extensions.colibri2.Connect
+import org.jivesoftware.smack.packet.StanzaError
 import java.net.URI
 
 class ExporterWrapper internal constructor(
@@ -48,8 +50,8 @@ class ExporterWrapper internal constructor(
 
     private val exporterFactory: (Connect) -> Exporter = exporterFactory ?: ::createExporter
 
-    /** One running [Exporter] per requested connect, keyed by the connect's URL. */
-    private val exporters = mutableMapOf<URI, Entry>()
+    /** One running [Exporter] per requested connect, keyed by the connect's id. */
+    private val exporters = mutableMapOf<String, Entry>()
 
     /**
      * The running exporters exposed as [PotentialPacketHandler]s for the conference's send path. Each exporter is an
@@ -64,50 +66,73 @@ class ExporterWrapper internal constructor(
     fun getPacketHandlers(): List<PotentialPacketHandler> = packetHandlers
 
     /**
-     * Reconcile the running exporters with the requested set of connects, using the URL as the connect's identity:
-     *  - stop exporters whose URL is no longer requested,
-     *  - start exporters for URLs that weren't already running,
-     *  - for URLs that are still requested, pass any change in the connect's other parameters to the existing
-     *    exporter as an update.
+     * Apply a delta of connects, using the connect's [Connect.id] as its identity. Connects not mentioned are left
+     * running unchanged. Each connect is one of:
+     *  - `expire=true`: stop and remove the exporter with that id (a no-op with a warning if it isn't running),
+     *  - `create=true`: start a new exporter; rejected if an exporter with that id is already running,
+     *  - neither: update the already-running exporter with that id; rejected if none is running (i.e. a connect for a
+     *    new id must set `create`). Only the exported/requested source names can change live; any other change is
+     *    rejected.
+     *
+     * The whole delta is validated before anything is applied, so a rejected connect doesn't disturb running exporters.
      */
-    fun setConnects(connects: List<Connect>) {
+    fun applyConnects(connects: List<Connect>) {
         // Validate up front so a rejected connect doesn't disturb the already-running exporters.
         connects.forEach { validate(it) }
 
-        val desired = connects.associateBy { it.url }
-        val desiredParams = desired.mapValues { (_, connect) -> ConnectParams(connect) }
-
-        // Fail before changing anything if a still-running connect changed in a way that can't be applied to a live
-        // exporter (e.g. HTTP headers, which are fixed when the websocket connects). Only the exported/requested
-        // source names can be updated in place.
-        desiredParams.forEach { (url, params) ->
-            val running = exporters[url]?.params ?: return@forEach
-            val unsupported = running.nonUpdatableChangesTo(params)
-            if (unsupported.isNotEmpty()) {
-                throw FeatureNotImplementedException(
-                    "Updating connect ${unsupported.joinToString()} for url=$url"
-                )
+        // Pass 1: classify each connect and fail before mutating anything.
+        val toExpire = mutableListOf<String>()
+        val toCreate = mutableListOf<Connect>()
+        val toUpdate = mutableListOf<Pair<Connect, ConnectParams>>()
+        connects.forEach { connect ->
+            val id = connect.id
+            when {
+                connect.expire -> toExpire += id
+                connect.create -> {
+                    if (exporters.containsKey(id)) {
+                        throw IqProcessingException(
+                            StanzaError.Condition.bad_request,
+                            "Connect with create=true for an already-existing id=$id"
+                        )
+                    }
+                    toCreate += connect
+                }
+                else -> {
+                    val running = exporters[id] ?: throw IqProcessingException(
+                        StanzaError.Condition.bad_request,
+                        "Connect for unknown id=$id without create=true"
+                    )
+                    val params = ConnectParams(connect)
+                    val unsupported = running.params.nonUpdatableChangesTo(params)
+                    if (unsupported.isNotEmpty()) {
+                        throw FeatureNotImplementedException(
+                            "Updating connect ${unsupported.joinToString()} for id=$id"
+                        )
+                    }
+                    toUpdate += connect to params
+                }
             }
         }
 
-        // Stop exporters whose URL is no longer requested.
-        (exporters.keys - desired.keys).forEach { url ->
-            logger.info("Stopping exporter for url=$url")
-            exporters.remove(url)?.exporter?.stop()
+        // Pass 2: apply.
+        toExpire.forEach { id ->
+            val removed = exporters.remove(id)
+            if (removed != null) {
+                logger.info("Stopping exporter id=$id")
+                removed.exporter.stop()
+            } else {
+                logger.warn("Received expire for unknown connect id=$id")
+            }
         }
-
-        desired.forEach { (url, connect) ->
-            val params = desiredParams.getValue(url)
-            val existing = exporters[url]
-            when {
-                // A URL that wasn't running: start a new exporter for it.
-                existing == null -> exporters[url] = Entry(exporterFactory(connect), params)
-                // A URL that was running and changed: only exports/requests can reach here (others threw above).
-                existing.params != params -> {
-                    logger.info("Updating exporter for url=$url")
-                    existing.exporter.update(params.exports, params.requests)
-                    existing.params = params
-                }
+        toCreate.forEach { connect ->
+            exporters[connect.id] = Entry(exporterFactory(connect), ConnectParams(connect))
+        }
+        toUpdate.forEach { (connect, params) ->
+            val existing = exporters.getValue(connect.id)
+            if (existing.params != params) {
+                logger.info("Updating exporter id=${connect.id}")
+                existing.exporter.update(params.exports, params.requests)
+                existing.params = params
             }
         }
 
@@ -177,11 +202,12 @@ class ExporterWrapper internal constructor(
     private class Entry(val exporter: Exporter, var params: ConnectParams)
 
     /**
-     * The parameters of a [Connect] other than its URL (which is its identity). Used to detect whether a re-signaled
-     * connect for an already-running URL has changed and therefore needs to be passed to the exporter as an update.
+     * The parameters of a [Connect] other than its id (which is its identity). Used to detect whether a re-signaled
+     * connect for an already-running id has changed and therefore needs to be passed to the exporter as an update.
      * Source-name lists are normalized (sorted) so reordering alone isn't treated as a change.
      */
     private data class ConnectParams(
+        val url: URI,
         val protocol: Connect.Protocols,
         val type: Connect.Types,
         val audio: Boolean,
@@ -193,6 +219,7 @@ class ExporterWrapper internal constructor(
         val requests: List<String>
     ) {
         constructor(connect: Connect) : this(
+            connect.url,
             connect.protocol,
             connect.type,
             connect.audio,
@@ -211,6 +238,7 @@ class ExporterWrapper internal constructor(
          * constrains them.
          */
         fun nonUpdatableChangesTo(other: ConnectParams): List<String> = buildList {
+            if (url != other.url) add("url")
             if (type != other.type) add("type")
             if (audio != other.audio) add("audio")
             if (headers != other.headers) add("headers")

--- a/jvb/src/test/kotlin/org/jitsi/videobridge/export/ExporterWrapperTest.kt
+++ b/jvb/src/test/kotlin/org/jitsi/videobridge/export/ExporterWrapperTest.kt
@@ -22,29 +22,40 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.jitsi.utils.logging2.LoggerImpl
 import org.jitsi.videobridge.colibri2.FeatureNotImplementedException
+import org.jitsi.videobridge.colibri2.IqProcessingException
 import org.jitsi.xmpp.extensions.colibri2.Connect
 import java.net.URI
 
 class ExporterWrapperTest : ShouldSpec() {
     private val logger = LoggerImpl(javaClass.name)
 
-    /** Records the mock [Exporter] created for each connect URL, so tests can verify calls against them. */
+    /** Records the mock [Exporter] created for each connect id, so tests can verify calls against them. */
     private inner class Fixture {
-        val exporters = mutableMapOf<URI, Exporter>()
+        val exporters = mutableMapOf<String, Exporter>()
         val wrapper = ExporterWrapper(logger, { }, { }, { null }) { connect ->
-            mockk<Exporter>(relaxed = true).also { exporters[connect.url] = it }
+            mockk<Exporter>(relaxed = true).also { exporters[connect.id] = it }
         }
-        operator fun get(url: String): Exporter = exporters.getValue(URI(url))
+        operator fun get(id: String): Exporter = exporters.getValue(id)
     }
 
     private fun connect(
-        url: String,
+        id: String,
+        url: String = "wss://example.com/$id",
         type: Connect.Types = Connect.Types.TRANSCRIBER,
+        create: Boolean = false,
+        expire: Boolean = false,
         headers: Map<String, String> = emptyMap(),
         exports: List<String> = emptyList(),
         requests: List<String> = emptyList(),
         ping: Pair<Int, Int>? = null
-    ): Connect = Connect(URI(url), Connect.Protocols.MEDIAJSON, type).apply {
+    ): Connect = Connect(
+        id = id,
+        url = URI(url),
+        protocol = Connect.Protocols.MEDIAJSON,
+        type = type,
+        create = create,
+        expire = expire
+    ).apply {
         headers.forEach { (n, v) -> addHttpHeader(n, v) }
         exports.forEach { addExport(it) }
         requests.forEach { addRequest(it) }
@@ -52,107 +63,179 @@ class ExporterWrapperTest : ShouldSpec() {
     }
 
     init {
-        val urlA = "wss://example.com/a"
-        val urlB = "wss://example.com/b"
-
-        context("Starting connects") {
-            should("create an exporter per connect") {
+        context("Creating connects") {
+            should("create an exporter per connect, keyed by id") {
                 val f = Fixture()
-                f.wrapper.setConnects(listOf(connect(urlA), connect(urlB)))
+                f.wrapper.applyConnects(listOf(connect("a", create = true), connect("b", create = true)))
 
                 f.wrapper.started shouldBe true
-                f.exporters.keys shouldBe setOf(URI(urlA), URI(urlB))
+                f.exporters.keys shouldBe setOf("a", "b")
             }
-            should("stop all and mark not started when given an empty list") {
+            should("allow multiple connects with the same url but different ids") {
                 val f = Fixture()
-                f.wrapper.setConnects(listOf(connect(urlA), connect(urlB)))
+                val url = "wss://example.com/shared"
+                f.wrapper.applyConnects(
+                    listOf(connect("a", url = url, create = true), connect("b", url = url, create = true))
+                )
 
-                f.wrapper.setConnects(emptyList())
+                f.exporters.keys shouldBe setOf("a", "b")
+            }
+            should("reject create for an already-existing id") {
+                val f = Fixture()
+                f.wrapper.applyConnects(listOf(connect("a", create = true)))
 
+                shouldThrow<IqProcessingException> {
+                    f.wrapper.applyConnects(listOf(connect("a", create = true)))
+                }
+                verify(exactly = 0) { f["a"].stop() }
+            }
+            should("reject a connect for an unknown id without create") {
+                val f = Fixture()
+                shouldThrow<IqProcessingException> {
+                    f.wrapper.applyConnects(listOf(connect("a")))
+                }
                 f.wrapper.started shouldBe false
-                verify(exactly = 1) { f[urlA].stop() }
-                verify(exactly = 1) { f[urlB].stop() }
             }
         }
 
-        context("Reconciling connects") {
-            should("stop only the exporters whose URL is no longer requested") {
+        context("Delta semantics") {
+            should("leave unmentioned connects running") {
                 val f = Fixture()
-                f.wrapper.setConnects(listOf(connect(urlA), connect(urlB)))
+                f.wrapper.applyConnects(listOf(connect("a", create = true), connect("b", create = true)))
 
-                f.wrapper.setConnects(listOf(connect(urlA)))
+                // A delta that only updates 'a' must not touch 'b'.
+                f.wrapper.applyConnects(listOf(connect("a", exports = listOf("s1"))))
 
-                verify(exactly = 0) { f[urlA].stop() }
-                verify(exactly = 1) { f[urlB].stop() }
+                verify(exactly = 0) { f["a"].stop() }
+                verify(exactly = 0) { f["b"].stop() }
                 f.wrapper.started shouldBe true
             }
-            should("not recreate or update an exporter when an identical connect is re-signaled") {
+            should("not stop everything on an empty delta") {
                 val f = Fixture()
-                f.wrapper.setConnects(listOf(connect(urlA, exports = listOf("s1"))))
+                f.wrapper.applyConnects(listOf(connect("a", create = true)))
 
-                f.wrapper.setConnects(listOf(connect(urlA, exports = listOf("s1"))))
+                f.wrapper.applyConnects(emptyList())
 
-                f.exporters.size shouldBe 1
-                verify(exactly = 0) { f[urlA].update(any(), any()) }
+                verify(exactly = 0) { f["a"].stop() }
+                f.wrapper.started shouldBe true
+            }
+            should("expire only the named connect") {
+                val f = Fixture()
+                f.wrapper.applyConnects(listOf(connect("a", create = true), connect("b", create = true)))
+
+                f.wrapper.applyConnects(listOf(connect("b", expire = true)))
+
+                verify(exactly = 0) { f["a"].stop() }
+                verify(exactly = 1) { f["b"].stop() }
+                f.wrapper.started shouldBe true
+            }
+            should("ignore an expire for an unknown id") {
+                val f = Fixture()
+                f.wrapper.applyConnects(listOf(connect("a", create = true)))
+
+                f.wrapper.applyConnects(listOf(connect("unknown", expire = true)))
+
+                f.exporters.keys shouldBe setOf("a")
+                verify(exactly = 0) { f["a"].stop() }
+            }
+        }
+
+        context("stop()") {
+            should("stop all exporters and mark not started") {
+                val f = Fixture()
+                f.wrapper.applyConnects(listOf(connect("a", create = true), connect("b", create = true)))
+
+                f.wrapper.stop()
+
+                f.wrapper.started shouldBe false
+                verify(exactly = 1) { f["a"].stop() }
+                verify(exactly = 1) { f["b"].stop() }
             }
         }
 
         context("Updating exports/requests in place") {
             should("apply changed exports and requests to the running exporter") {
                 val f = Fixture()
-                f.wrapper.setConnects(listOf(connect(urlA, exports = listOf("s1"), requests = listOf("s1.en"))))
-
-                f.wrapper.setConnects(
-                    listOf(connect(urlA, exports = listOf("s1", "s2"), requests = listOf("s1.en", "s2.fr")))
+                f.wrapper.applyConnects(
+                    listOf(connect("a", create = true, exports = listOf("s1"), requests = listOf("s1.en")))
                 )
 
-                verify(exactly = 1) { f[urlA].update(listOf("s1", "s2"), listOf("s1.en", "s2.fr")) }
-                verify(exactly = 0) { f[urlA].stop() }
+                f.wrapper.applyConnects(
+                    listOf(connect("a", exports = listOf("s1", "s2"), requests = listOf("s1.en", "s2.fr")))
+                )
+
+                verify(exactly = 1) { f["a"].update(listOf("s1", "s2"), listOf("s1.en", "s2.fr")) }
+                verify(exactly = 0) { f["a"].stop() }
+            }
+            should("not update for an identical re-signaled connect") {
+                val f = Fixture()
+                f.wrapper.applyConnects(listOf(connect("a", create = true, exports = listOf("s1"))))
+
+                f.wrapper.applyConnects(listOf(connect("a", exports = listOf("s1"))))
+
+                verify(exactly = 0) { f["a"].update(any(), any()) }
             }
             should("not treat reordered source names as a change") {
                 val f = Fixture()
-                f.wrapper.setConnects(listOf(connect(urlA, exports = listOf("s1", "s2"))))
+                f.wrapper.applyConnects(listOf(connect("a", create = true, exports = listOf("s1", "s2"))))
 
-                f.wrapper.setConnects(listOf(connect(urlA, exports = listOf("s2", "s1"))))
+                f.wrapper.applyConnects(listOf(connect("a", exports = listOf("s2", "s1"))))
 
-                verify(exactly = 0) { f[urlA].update(any(), any()) }
+                verify(exactly = 0) { f["a"].update(any(), any()) }
             }
         }
 
         context("Rejecting non-updatable changes") {
             should("throw and leave the exporter untouched when HTTP headers change") {
                 val f = Fixture()
-                f.wrapper.setConnects(listOf(connect(urlA, headers = mapOf("Authorization" to "Bearer a"))))
+                f.wrapper.applyConnects(
+                    listOf(connect("a", create = true, headers = mapOf("Authorization" to "Bearer a")))
+                )
 
                 shouldThrow<FeatureNotImplementedException> {
-                    f.wrapper.setConnects(listOf(connect(urlA, headers = mapOf("Authorization" to "Bearer b"))))
+                    f.wrapper.applyConnects(listOf(connect("a", headers = mapOf("Authorization" to "Bearer b"))))
                 }
 
-                verify(exactly = 0) { f[urlA].stop() }
-                verify(exactly = 0) { f[urlA].update(any(), any()) }
+                verify(exactly = 0) { f["a"].stop() }
+                verify(exactly = 0) { f["a"].update(any(), any()) }
             }
             should("throw when the ping configuration changes") {
                 val f = Fixture()
-                f.wrapper.setConnects(listOf(connect(urlA, ping = 1000 to 2000)))
+                f.wrapper.applyConnects(listOf(connect("a", create = true, ping = 1000 to 2000)))
 
                 shouldThrow<FeatureNotImplementedException> {
-                    f.wrapper.setConnects(listOf(connect(urlA, ping = 3000 to 4000)))
+                    f.wrapper.applyConnects(listOf(connect("a", ping = 3000 to 4000)))
+                }
+            }
+            should("throw when the url changes for an existing id") {
+                val f = Fixture()
+                f.wrapper.applyConnects(listOf(connect("a", url = "wss://example.com/a1", create = true)))
+
+                shouldThrow<FeatureNotImplementedException> {
+                    f.wrapper.applyConnects(listOf(connect("a", url = "wss://example.com/a2")))
                 }
             }
             should("throw when the type changes") {
                 val f = Fixture()
-                f.wrapper.setConnects(listOf(connect(urlA, type = Connect.Types.TRANSCRIBER)))
+                f.wrapper.applyConnects(listOf(connect("a", create = true, type = Connect.Types.TRANSCRIBER)))
 
                 shouldThrow<FeatureNotImplementedException> {
-                    f.wrapper.setConnects(listOf(connect(urlA, type = Connect.Types.TRANSLATOR)))
+                    f.wrapper.applyConnects(listOf(connect("a", type = Connect.Types.TRANSLATOR)))
                 }
             }
             should("reject a video connect") {
                 val f = Fixture()
-                val videoConnect = Connect(URI(urlA), Connect.Protocols.MEDIAJSON, Connect.Types.RECORDER, video = true)
+                val videoConnect = Connect(
+                    id = "a",
+                    url = URI("wss://example.com/a"),
+                    protocol = Connect.Protocols.MEDIAJSON,
+                    type = Connect.Types.RECORDER,
+                    video = true,
+                    create = true
+                )
 
                 shouldThrow<FeatureNotImplementedException> {
-                    f.wrapper.setConnects(listOf(videoConnect))
+                    f.wrapper.applyConnects(listOf(videoConnect))
                 }
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-xmpp-extensions</artifactId>
-                <version>1.0-113-g4281255</version>
+                <version>1.0-114-g087129a</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Builds on JonathanLennox/jitsi-videobridge `colibri2-multiple-connects` (jitsi/jitsi-videobridge#2419).

`ExporterWrapper` now keys exporters by connect **id** instead of URL and applies the signaled connects as a **delta**:

- a connect marked `create` starts a new exporter (throws if the id already exists);
- `expire` removes one (throws on unknown id for create, or on a non-create change to an unknown id);
- an unmarked connect updates the existing one;
- connects not mentioned in a request are left untouched.

Throwing on inconsistent create/expire markers surfaces message-ordering problems instead of silently mishandling them.

Depends on jitsi/jitsi-xmpp-extensions#143 (the id/create/expire attributes). pom bump to the released version follows after that merges.